### PR TITLE
Update opam metadata

### DIFF
--- a/xenctrl.opam
+++ b/xenctrl.opam
@@ -2,9 +2,9 @@ opam-version: "2.0"
 synopsis: "Mock OCaml bindings for the Xen Hypervisor"
 maintainer: "lindig@gmail.com"
 authors: "lindig@gmail.com"
-license: "LGPL"
-homepage: "https://github.com/lindig/xenctrl"
-bug-reports: "https://github.com/lindig/xenctrl/issues"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/xapi-project/xenctrl"
+bug-reports: "https://github.com/xapi-project/xenctrl/issues"
 depends: [
   "ocaml"
   "dune" {build}


### PR DESCRIPTION
Use the correct SPDX identifier and change the urls to xapi-project

Signed-off-by: Pau Ruiz Safont <pau.safont@citrix.com>