### PR TITLE
CP-38617: expose xentoollog library the same way xen does

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,1 +1,3 @@
-(lang dune 1.3)
+(lang dune 2.0)
+
+(formatting disabled)

--- a/libs/eventchn/dune
+++ b/libs/eventchn/dune
@@ -1,7 +1,8 @@
-
 (library
- (name            xeneventchn)
- (public_name     xenctrl.xeneventchn)
- (libraries       unix)
- (c_names         xeneventchn_stubs)
+ (foreign_stubs
+  (language c)
+  (names xeneventchn_stubs))
+ (name xeneventchn)
+ (public_name xenctrl.xeneventchn)
+ (libraries unix)
  (c_library_flags -lxenevtchn))

--- a/libs/mmap/dune
+++ b/libs/mmap/dune
@@ -1,7 +1,8 @@
-
 (library
- (name               xenmmap)
- (public_name        xenctrl.xenmmap)
- (libraries          unix)
- (c_names            xenmmap_stubs)
- (install_c_headers  mmap_stubs))
+ (foreign_stubs
+  (language c)
+  (names xenmmap_stubs))
+ (name xenmmap)
+ (public_name xenctrl.xenmmap)
+ (libraries unix)
+ (install_c_headers mmap_stubs))

--- a/libs/xb/dune
+++ b/libs/xb/dune
@@ -1,7 +1,8 @@
-
 (library
- (name            xenbus)
- (public_name     xenctrl.xenbus)
- (libraries       unix xenmmap)
- (c_names         xenbus_stubs xs_ring_stubs)
+ (foreign_stubs
+  (language c)
+  (names xenbus_stubs xs_ring_stubs))
+ (name xenbus)
+ (public_name xenctrl.xenbus)
+ (libraries unix xenmmap)
  (c_library_flags -lxenctrl))

--- a/libs/xc/dune
+++ b/libs/xc/dune
@@ -1,9 +1,10 @@
-
 (library
- (name            xenctrl)
- (public_name     xenctrl)
- (libraries       unix xenmmap)
- (c_names         xenctrl_stubs)
+ (foreign_stubs
+  (language c)
+  (names xenctrl_stubs))
+ (name xenctrl)
+ (public_name xenctrl)
+ (libraries unix xenmmap)
  (c_library_flags
   -lxenctrl
   -lxenguest

--- a/libs/xentoollog/dune
+++ b/libs/xentoollog/dune
@@ -1,7 +1,7 @@
 
 (library
  (name              xentoollog)
- (public_name       xenctrl.xentoollog)
+ (public_name       xentoollog)
  (libraries         unix)
  (c_names           xentoollog_stubs)
  (install_c_headers caml_xentoollog)

--- a/libs/xentoollog/dune
+++ b/libs/xentoollog/dune
@@ -1,9 +1,9 @@
-
 (library
- (name              xentoollog)
- (public_name       xentoollog)
- (libraries         unix)
- (c_names           xentoollog_stubs)
+ (foreign_stubs
+  (language c)
+  (names xentoollog_stubs))
+ (name xentoollog)
+ (public_name xentoollog)
+ (libraries unix)
  (install_c_headers caml_xentoollog)
- (c_library_flags   -lxentoollog))
-
+ (c_library_flags -lxentoollog))

--- a/libs/xs/dune
+++ b/libs/xs/dune
@@ -1,5 +1,4 @@
-
 (library
- (name            xenstore)
- (public_name     xenctrl.xenstore)
- (libraries       unix xenbus))
+ (name xenstore)
+ (public_name xenctrl.xenstore)
+ (libraries unix xenbus))

--- a/xenctrl.opam
+++ b/xenctrl.opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/xapi-project/xenctrl"
 bug-reports: "https://github.com/xapi-project/xenctrl/issues"
 depends: [
   "ocaml"
-  "dune" {build}
+  "dune" {>= "2.0"}
   "base-unix"
 ]
 build: ["dune" "build" "-p" name "-j" jobs]

--- a/xenctrl.opam
+++ b/xenctrl.opam
@@ -1,28 +1,19 @@
 opam-version: "2.0"
 synopsis: "Mock OCaml bindings for the Xen Hypervisor"
-maintainer: "lindig@gmail.com"
-authors: "lindig@gmail.com"
+maintainer: "xen-api@lists.xen.org"
+authors: "Christian Lindig <christian.lindig@citrix.com>"
 license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 homepage: "https://github.com/xapi-project/xenctrl"
 bug-reports: "https://github.com/xapi-project/xenctrl/issues"
 depends: [
   "ocaml"
+  "conf-xen"
   "dune" {>= "2.0"}
   "base-unix"
 ]
 build: ["dune" "build" "-p" name "-j" jobs]
-depexts: [
-  ["m4" "libxen-dev" "libsystemd-dev"] {os-distribution = "debian"}
-  ["libxen-dev" "uuid-dev"] {os-distribution = "ubuntu"}
-  ["xen-devel" "libuuid-devel"] {os-distribution = "centos"}
-  ["xen-devel"] {os-distribution = "fedora"}
-  ["xen-devel"] {os-distribution = "rhel"}
-  ["xen-devel"] {os-distribution = "oraclelinux"}
-  ["xen-dom0-libs-devel" "xen-libs-devel"] {os = "xenserver"}
-  ["xen-dev"] {os-distribution = "alpine"}
-]
 
-dev-repo: "git+https://github.com/lindig/xenctrl.git"
+dev-repo: "git+https://github.com/xapi-project/xenctrl.git"
 url {
-  src: "https://github.com/lindig/xenctrl/archive/master.tar.gz"
+  src: "https://github.com/xapi-project/xenctrl/archive/master.tar.gz"
 }

--- a/xentoollog.opam
+++ b/xentoollog.opam
@@ -11,16 +11,6 @@ depends: [
   "base-unix"
 ]
 build: ["dune" "build" "-p" name "-j" jobs]
-depexts: [
-  ["m4" "libxen-dev" "libsystemd-dev"] {os-distribution = "debian"}
-  ["libxen-dev" "uuid-dev"] {os-distribution = "ubuntu"}
-  ["xen-devel" "libuuid-devel"] {os-distribution = "centos"}
-  ["xen-devel"] {os-distribution = "fedora"}
-  ["xen-devel"] {os-distribution = "rhel"}
-  ["xen-devel"] {os-distribution = "oraclelinux"}
-  ["xen-dom0-libs-devel" "xen-libs-devel"] {os = "xenserver"}
-  ["xen-dev"] {os-distribution = "alpine"}
-]
 
 dev-repo: "git+https://github.com/xapi-project/xenctrl.git"
 url {

--- a/xentoollog.opam
+++ b/xentoollog.opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/xapi-project/xenctrl"
 bug-reports: "https://github.com/xapi-project/xenctrl/issues"
 depends: [
   "ocaml"
-  "dune" {build}
+  "dune" {>= "2.0"}
   "base-unix"
 ]
 build: ["dune" "build" "-p" name "-j" jobs]

--- a/xentoollog.opam
+++ b/xentoollog.opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "Mock OCaml bindings for Xen's xentoollog"
+maintainer: "xen-api@lists.xen.org"
+authors: "Christian Lindig <christian.lindig@citrix.com>"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/xapi-project/xenctrl"
+bug-reports: "https://github.com/xapi-project/xenctrl/issues"
+depends: [
+  "ocaml"
+  "dune" {build}
+  "base-unix"
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+depexts: [
+  ["m4" "libxen-dev" "libsystemd-dev"] {os-distribution = "debian"}
+  ["libxen-dev" "uuid-dev"] {os-distribution = "ubuntu"}
+  ["xen-devel" "libuuid-devel"] {os-distribution = "centos"}
+  ["xen-devel"] {os-distribution = "fedora"}
+  ["xen-devel"] {os-distribution = "rhel"}
+  ["xen-devel"] {os-distribution = "oraclelinux"}
+  ["xen-dom0-libs-devel" "xen-libs-devel"] {os = "xenserver"}
+  ["xen-dev"] {os-distribution = "alpine"}
+]
+
+dev-repo: "git+https://github.com/xapi-project/xenctrl.git"
+url {
+  src: "https://github.com/xapi-project/xenctrl/archive/master.tar.gz"
+}


### PR DESCRIPTION
This unfortunately means creating a new package that will need to be added to xs-opam so xen-api picks it as well.

This is needed to make this branch to compile in a dev environment: https://github.com/psafont/xen-api/tree/private/paus/xen-foreign