### PR TITLE
Upstream Xen has xenmmap as separate package, no xenctrl.xenmmap

### DIFF
--- a/libs/mmap/dune
+++ b/libs/mmap/dune
@@ -3,6 +3,6 @@
   (language c)
   (names xenmmap_stubs))
  (name xenmmap)
- (public_name xenctrl.xenmmap)
+ (public_name xenmmap)
  (libraries unix)
  (install_c_headers mmap_stubs))

--- a/xenmmap.opam
+++ b/xenmmap.opam
@@ -10,7 +10,6 @@ depends: [
   "conf-xen"
   "dune" {>= "2.0"}
   "base-unix"
-  "xenmmap"
 ]
 build: ["dune" "build" "-p" name "-j" jobs]
 


### PR DESCRIPTION
If we disable transitive dependencies in dune then we need to depend on 'xenmmap' in Koji, not 'xenctrl.xenmmap' (which doesn't exist). But 'xenmmap' has no 'mock', so rename the library to have one.