### PR TITLE
Fix warnings

### DIFF
--- a/libs/xb/xenbus_stubs.c
+++ b/libs/xb/xenbus_stubs.c
@@ -65,7 +65,7 @@ CAMLprim value stub_string_of_header(value tid, value rid, value ty, value len)
 	};
 
 	ret = caml_alloc_string(sizeof(struct xsd_sockmsg));
-	memcpy(String_val(ret), &xsd, sizeof(struct xsd_sockmsg));
+	memcpy((void*) String_val(ret), &xsd, sizeof(struct xsd_sockmsg));
 
 	CAMLreturn(ret);
 }

--- a/libs/xb/xs_ring_stubs.c
+++ b/libs/xb/xs_ring_stubs.c
@@ -44,7 +44,7 @@ CAMLprim value ml_interface_read(value ml_interface,
 	CAMLlocal1(ml_result);
 
 	struct mmap_interface *interface = GET_C_STRUCT(ml_interface);
-	char *buffer = String_val(ml_buffer);
+	char *buffer = (char*) String_val(ml_buffer);
 	int len = Int_val(ml_len);
 	int result;
 
@@ -103,7 +103,7 @@ CAMLprim value ml_interface_write(value ml_interface,
 	CAMLlocal1(ml_result);
 
 	struct mmap_interface *interface = GET_C_STRUCT(ml_interface);
-	char *buffer = String_val(ml_buffer);
+	char *buffer = (char*) String_val(ml_buffer);
 	int len = Int_val(ml_len);
 	int result;
 

--- a/libs/xentoollog/xentoollog_stubs.c
+++ b/libs/xentoollog/xentoollog_stubs.c
@@ -52,9 +52,11 @@ static char * dup_String_val(value s)
 
 #include "_xtl_levels.h"
 
-/* Option type support as per http://www.linux-nantes.org/~fmonnier/ocaml/ocaml-wrapping-c.php */
-#define Val_none Val_int(0)
-#define Some_val(v) Field(v,0)
+/* Introduced in OCaml 4.12. */
+#ifndef Some_val
+	#define Val_none Val_int(0)
+	#define Some_val(v) Field(v, 0)
+#endif
 
 static value Val_some(value v)
 {
@@ -90,7 +92,7 @@ static void stub_xtl_ocaml_vmessage(struct xentoollog_logger *logger,
 	CAMLparam0();
 	CAMLlocalN(args, 4);
 	struct caml_xtl *xtl = (struct caml_xtl*)logger;
-	value *func = caml_named_value(xtl->vmessage_cb) ;
+	const value *func = caml_named_value(xtl->vmessage_cb) ;
 	char *msg;
 
 	if (func == NULL)
@@ -120,7 +122,7 @@ static void stub_xtl_ocaml_progress(struct xentoollog_logger *logger,
 	CAMLparam0();
 	CAMLlocalN(args, 5);
 	struct caml_xtl *xtl = (struct caml_xtl*)logger;
-	value *func = caml_named_value(xtl->progress_cb) ;
+	const value *func = caml_named_value(xtl->progress_cb) ;
 
 	if (func == NULL)
 		caml_raise_sys_error(caml_copy_string("Unable to find callback"));


### PR DESCRIPTION
No change to what is built, simply addressing warnings pertaining to casting and redefining of macros.

---

- Explicitly casts the `const` qualifier off of that provided by `String_val`.
- Explicitly adds `const` to various places.
- Conditionally defines `Val_none` and `Some_val` (added to trunk OCaml in 4.12).