### PR TITLE
CP-308452: Update xenctrl library the same way patched xen does

### DIFF
--- a/libs/xc/xenctrl.ml
+++ b/libs/xc/xenctrl.ml
@@ -99,6 +99,7 @@ type runstateinfo = {
   time3 : int64;
   time4 : int64;
   time5 : int64;
+  runnable : int64;
 }
 
 type domaininfo =

--- a/libs/xc/xenctrl.mli
+++ b/libs/xc/xenctrl.mli
@@ -91,6 +91,7 @@ type runstateinfo = {
   time3 : int64;
   time4 : int64;
   time5 : int64;
+  runnable : int64;
 }
 
 type domaininfo = {


### PR DESCRIPTION
Add "runnable" field to "runstateinfo" the same as updated mixed-domain-runstates.patch does.