### PR TITLE
Add missing NUMA stub function

### DIFF
--- a/libs/xc/xenctrl_stubs.c
+++ b/libs/xc/xenctrl_stubs.c
@@ -51,3 +51,10 @@ CAMLprim value mock5 (value v1, value v2, value v3, value v4, value v5)
   caml_failwith(msg);
   CAMLreturn (result);
 }
+
+CAMLprim value stub_xc_domain_numa_get_node_pages(value v1, value v2)
+{
+    CAMLparam2(v1, v2);
+    caml_failwith(__func__);
+    CAMLnoreturn;
+}


### PR DESCRIPTION
If this is missing *and* you have a new enough Xen with the headers that defines this NUMA stub,  then linking the XAPI unit tests would fail with:
```
File "ocaml/xenopsd/xc/dune", line 83, characters 7-21:
83 |  (name xenops_xc_main)
            ^^^^^^^^^^^^^^
/usr/bin/ld: ocaml/libs/xenctrl-ext/libxenctrl_ext_stubs.a(xenctrlext_stubs.o): in function `stub_xc_domain_numa_get_node_pages_wrapper':
/home/edvint-670/git/xen-api/_build/default/ocaml/libs/xenctrl-ext/xenctrlext_stubs.c:762:(.text+0x1d61): undefined reference to `stub_xc_domain_numa_get_node_pages'
```

The implementation of that function would be in xenctrl_stubs.c, but the mock xenctrl here replaces that (the headers come from the real xenctrl, and declare that this function is implemented).

The way this stub is implemented in xenctrlext in xenopsd is unusual, because it directly calls another C stub implemented in another library. None of the other stubs work that way: they usually implement the functionality themselves.